### PR TITLE
side_footer: Use correct doc links

### DIFF
--- a/public_html/widgets/side_footer.php
+++ b/public_html/widgets/side_footer.php
@@ -19,7 +19,7 @@
         </li>
 
         <li>
-            <a href="https://github.com/tootsuite/mastodon/blob/master/docs/Using-Mastodon/Apps.md">Apps</a>
+            <a href="https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/Apps.md">Apps</a>
         </li>
 
         <li>
@@ -27,7 +27,7 @@
         </li>
 
         <li>
-            <a href="https://github.com/tootsuite/mastodon/blob/master/docs/Using-Mastodon/List-of-Mastodon-instances.md">Other instances</a>
+            <a href="https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/List-of-Mastodon-instances.md">Other instances</a>
         </li>
         
     </ul>


### PR DESCRIPTION
https://github.com/tootsuite/mastodon/tree/master/docs
> The documentation has moved to its own repository
